### PR TITLE
feat: allow marquee to be scrollable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ How It Works
 - `pauseOnHover` (optional): A boolean to pause the scroll animation when the marquee is hovered. Defaults to true.
 - `vertical` (optional): A boolean to switch the marquee to vertical scrolling mode. Defaults to false.
 - `styleClass` (optional): A custom CSS class to apply to the .om-marquee container for additional styling.
+- `scrollable` (optional): A boolean to enable or disable the marquee scroll. Defaults to false.
 
 ## Example
 

--- a/src/lib/ngx-marquee.component.html
+++ b/src/lib/ngx-marquee.component.html
@@ -9,7 +9,7 @@
   <div class="om-marquee-invisible">
     <ng-content></ng-content>
   </div>
-  <div class="om-marquee-content" [class.outOfView]="!isInView">
+  <div class="om-marquee-content" [class.outOfView]="!isInView" [class.overflow-scroll]="scrollable">
     <div class="om-marquee-item-wrapper">
       @for (content of marqueeElements; track $index) {
       <div class="om-marquee-item" [innerHTML]="content"></div>

--- a/src/lib/ngx-marquee.component.scss
+++ b/src/lib/ngx-marquee.component.scss
@@ -29,6 +29,10 @@
     }
   }
 
+  .overflow-scroll {
+    overflow: auto;
+  }
+
   &.direction-row {
     .om-marquee-content {
       flex-direction: row;

--- a/src/lib/ngx-marquee.component.ts
+++ b/src/lib/ngx-marquee.component.ts
@@ -64,6 +64,9 @@ export class NgxMarqueeComponent implements AfterViewInit, AfterContentChecked, 
   @Input("vertical")
   vertical = false;
 
+  @Input("scrollable")
+  scrollable = false;
+
   style: any = {};
 
   marqueeElements: SafeHtml[] = [];


### PR DESCRIPTION
Added a scrollable input property to enable scrolling within the marquee. This allows users to manually scroll marquee content when needed. especially when the content is extremely long and I don't want to inscrease the animation duration.